### PR TITLE
Use string as kv in tracker store

### DIFF
--- a/tracker/store/boltdb/bolt_store.go
+++ b/tracker/store/boltdb/bolt_store.go
@@ -56,37 +56,37 @@ func (b *BoltStore) Close() error {
 }
 
 // Get implements the store interface
-func (b *BoltStore) Get(k []byte) ([]byte, error) {
+func (b *BoltStore) Get(k string) (string, error) {
 	txn, err := b.conn.Begin(false)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	defer txn.Rollback()
 
 	bucket := txn.Bucket(dbConf)
-	val := bucket.Get(k)
+	val := bucket.Get([]byte(k))
 
-	return val, nil
+	return string(val), nil
 }
 
 // ListPrefix implements the store interface
-func (b *BoltStore) ListPrefix(prefix []byte) ([][]byte, error) {
+func (b *BoltStore) ListPrefix(prefix string) ([]string, error) {
 	txn, err := b.conn.Begin(false)
 	if err != nil {
 		return nil, err
 	}
 	defer txn.Rollback()
 
-	res := [][]byte{}
+	res := []string{}
 	c := txn.Bucket(dbConf).Cursor()
-	for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
-		res = append(res, v)
+	for k, v := c.Seek([]byte(prefix)); k != nil && bytes.HasPrefix(k, []byte(prefix)); k, v = c.Next() {
+		res = append(res, string(v))
 	}
 	return res, nil
 }
 
 // Set implements the store interface
-func (b *BoltStore) Set(k, v []byte) error {
+func (b *BoltStore) Set(k, v string) error {
 	txn, err := b.conn.Begin(true)
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func (b *BoltStore) Set(k, v []byte) error {
 	defer txn.Rollback()
 
 	bucket := txn.Bucket(dbConf)
-	if err := bucket.Put(k, v); err != nil {
+	if err := bucket.Put([]byte(k), []byte(v)); err != nil {
 		return err
 	}
 	return txn.Commit()

--- a/tracker/store/inmem/inmem_store.go
+++ b/tracker/store/inmem/inmem_store.go
@@ -1,7 +1,7 @@
 package inmem
 
 import (
-	"bytes"
+	"strings"
 	"sync"
 
 	web3 "github.com/umbracle/go-web3"
@@ -14,14 +14,14 @@ var _ store.Store = (*InmemStore)(nil)
 type InmemStore struct {
 	l       sync.RWMutex
 	entries map[string]*Entry
-	kv      map[string][]byte
+	kv      map[string]string
 }
 
 // NewInmemStore returns a new in-memory store.
 func NewInmemStore() *InmemStore {
 	return &InmemStore{
 		entries: map[string]*Entry{},
-		kv:      map[string][]byte{},
+		kv:      map[string]string{},
 	}
 }
 
@@ -31,20 +31,20 @@ func (i *InmemStore) Close() error {
 }
 
 // Get implements the store interface
-func (i *InmemStore) Get(k []byte) ([]byte, error) {
+func (i *InmemStore) Get(k string) (string, error) {
 	i.l.Lock()
 	defer i.l.Unlock()
 	return i.kv[string(k)], nil
 }
 
 // ListPrefix implements the store interface
-func (i *InmemStore) ListPrefix(prefix []byte) ([][]byte, error) {
+func (i *InmemStore) ListPrefix(prefix string) ([]string, error) {
 	i.l.Lock()
 	defer i.l.Unlock()
 
-	res := [][]byte{}
+	res := []string{}
 	for k, v := range i.kv {
-		if bytes.HasPrefix([]byte(k), prefix) {
+		if strings.HasPrefix(k, prefix) {
 			res = append(res, v)
 		}
 	}
@@ -52,7 +52,7 @@ func (i *InmemStore) ListPrefix(prefix []byte) ([][]byte, error) {
 }
 
 // Set implements the store interface
-func (i *InmemStore) Set(k, v []byte) error {
+func (i *InmemStore) Set(k, v string) error {
 	i.l.Lock()
 	defer i.l.Unlock()
 	i.kv[string(k)] = v

--- a/tracker/store/postgresql/postgresql_store.go
+++ b/tracker/store/postgresql/postgresql_store.go
@@ -41,33 +41,29 @@ func (p *PostgreSQLStore) Close() error {
 }
 
 // Get implements the store interface
-func (p *PostgreSQLStore) Get(k []byte) ([]byte, error) {
+func (p *PostgreSQLStore) Get(k string) (string, error) {
 	var out string
 	if err := p.db.Get(&out, "SELECT val FROM kv WHERE key=$1", string(k)); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, nil
+			return "", nil
 		}
-		return nil, err
+		return "", err
 	}
-	return []byte(out), nil
+	return out, nil
 }
 
 // ListPrefix implements the store interface
-func (p *PostgreSQLStore) ListPrefix(prefix []byte) ([][]byte, error) {
+func (p *PostgreSQLStore) ListPrefix(prefix string) ([]string, error) {
 	var out []string
 	if err := p.db.Select(&out, "SELECT val FROM kv WHERE key LIKE $1", string(prefix)+"%"); err != nil {
 		return nil, err
 	}
-	res := [][]byte{}
-	for _, val := range out {
-		res = append(res, []byte(val))
-	}
-	return res, nil
+	return out, nil
 }
 
 // Set implements the store interface
-func (p *PostgreSQLStore) Set(k, v []byte) error {
-	if _, err := p.db.Exec("INSERT INTO kv (key, val) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET val = $2", string(k), string(v)); err != nil {
+func (p *PostgreSQLStore) Set(k, v string) error {
+	if _, err := p.db.Exec("INSERT INTO kv (key, val) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET val = $2", k, v); err != nil {
 		return err
 	}
 	return nil

--- a/tracker/store/store.go
+++ b/tracker/store/store.go
@@ -5,13 +5,13 @@ import web3 "github.com/umbracle/go-web3"
 // Store is a datastore for the tracker
 type Store interface {
 	// Get gets a value
-	Get(k []byte) ([]byte, error)
+	Get(k string) (string, error)
 
 	// ListPrefix lists values by prefix
-	ListPrefix(prefix []byte) ([][]byte, error)
+	ListPrefix(prefix string) ([]string, error)
 
 	// Set sets a value
-	Set(k, v []byte) error
+	Set(k, v string) error
 
 	// Close closes the store
 	Close() error

--- a/tracker/store/testing.go
+++ b/tracker/store/testing.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -67,9 +66,9 @@ func testPrefix(t *testing.T, setup SetupDB) {
 	store, close := setup(t)
 	defer close()
 
-	v1 := []byte("val1")
-	v2 := []byte("val2")
-	v3 := []byte("val3")
+	v1 := "val1"
+	v2 := "val2"
+	v3 := "val3"
 
 	// add same prefix values
 	if err := store.Set(v1, v1); err != nil {
@@ -83,11 +82,11 @@ func testPrefix(t *testing.T, setup SetupDB) {
 	}
 
 	// add distinct value
-	if err := store.Set([]byte("a"), []byte("b")); err != nil {
+	if err := store.Set("a", "b"); err != nil {
 		t.Fatal(err)
 	}
 
-	checkPrefix := func(prefix []byte, expected int) {
+	checkPrefix := func(prefix string, expected int) {
 		res, err := store.ListPrefix(prefix)
 		if err != nil {
 			t.Fatal(err)
@@ -97,18 +96,18 @@ func testPrefix(t *testing.T, setup SetupDB) {
 		}
 	}
 
-	checkPrefix([]byte("val"), 3)
-	checkPrefix([]byte("a"), 1)
-	checkPrefix([]byte("b"), 0)
+	checkPrefix("val", 3)
+	checkPrefix("a", 1)
+	checkPrefix("b", 0)
 }
 
 func testGetSet(t *testing.T, setup SetupDB) {
 	store, close := setup(t)
 	defer close()
 
-	k1 := []byte{0x1}
-	v1 := []byte{0x1}
-	v2 := []byte{0x2}
+	k1 := "k1"
+	v1 := "v1"
+	v2 := "v2"
 
 	res, err := store.Get(k1)
 	if err != nil {
@@ -126,7 +125,7 @@ func testGetSet(t *testing.T, setup SetupDB) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(res, v1) {
+	if res != v1 {
 		t.Fatal("bad")
 	}
 
@@ -138,7 +137,7 @@ func testGetSet(t *testing.T, setup SetupDB) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(res, v2) {
+	if res != v2 {
 		t.Fatal("bad")
 	}
 }


### PR DESCRIPTION
This PR changes the kv store to use string instead of []byte for keys and values because it is not easy to encode bytes in the Postgresql store.