### PR TITLE
Update abi.go

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -94,6 +94,7 @@ func (a *ABI) UnmarshalJSON(data []byte) error {
 			}
 
 		case "fallback":
+		case "receive":	
 			// do nothing
 
 		default:


### PR DESCRIPTION
Some smart contract ABI have 
"type":"receive"
like this one: https://bscscan.com/address/0x05ff2b0db69458a0750badebc4f9e13add608c7f#code

and this fix should allow that kind of ABI to be used.