### PR TITLE
Update transport.go

### DIFF
--- a/jsonrpc/transport/transport.go
+++ b/jsonrpc/transport/transport.go
@@ -30,7 +30,7 @@ func NewTransport(url string) (Transport, error) {
 	if strings.HasPrefix(url, wsPrefix) || strings.HasPrefix(url, wssPrefix) {
 		return newWebsocket(url)
 	}
-	if _, err := os.Stat(url); !os.IsNotExist(err) {
+	if _, err := os.Stat(url); err == nil {
 		// path exists, it could be an ipc path
 		return newIPC(url)
 	}


### PR DESCRIPTION
!os.IsNotExist(err) is not a proper way of checking if file exists in windows, because the os will return "malformed path" error instead of "file does not exists" so this code will treat eg. http://abc as a file which is accessible!