### PR TITLE
Fix empty response

### DIFF
--- a/abi/decode.go
+++ b/abi/decode.go
@@ -13,6 +13,9 @@ import (
 
 // Decode decodes the input with a given type
 func Decode(t *Type, input []byte) (interface{}, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("empty input")
+	}
 	val, _, err := decode(t, input)
 	return val, err
 }

--- a/abi/decode.go
+++ b/abi/decode.go
@@ -37,6 +37,11 @@ func decode(t *Type, input []byte) (interface{}, []byte, error) {
 	var length int
 	var err error
 
+	// safe check, input should be at least 32 bytes
+	if len(input) < 32 {
+		return nil, nil, fmt.Errorf("incorrect length")
+	}
+
 	if t.isVariableInput() {
 		length, err = readLength(input)
 		if err != nil {

--- a/contract/contract.go
+++ b/contract/contract.go
@@ -86,6 +86,9 @@ func (c *Contract) Call(method string, block web3.BlockNumber, args ...interface
 	if err != nil {
 		return nil, err
 	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty response")
+	}
 	respInterface, err := abi.Decode(m.Outputs, raw)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR closes #58. An empty input and thus the panic happens when you call a function that is not part of the contract and the eth_call returns an empty []byte. There should be a safe check on contract so that it fails on an empty response before checking Decode. Besides, we include some safe checks on abi as well.