### PR TITLE
Add hash and block filter for state endpoints

### DIFF
--- a/jsonrpc/eth.go
+++ b/jsonrpc/eth.go
@@ -20,9 +20,9 @@ func (c *Client) Eth() *Eth {
 }
 
 // GetCode returns the code of a contract
-func (e *Eth) GetCode(addr web3.Address) (string, error) {
+func (e *Eth) GetCode(addr web3.Address, block web3.BlockNumberOrHash) (string, error) {
 	var res string
-	if err := e.c.Call("eth_getCode", &res, addr, "latest"); err != nil {
+	if err := e.c.Call("eth_getCode", &res, addr, block.Location()); err != nil {
 		return "", err
 	}
 	return res, nil
@@ -38,9 +38,9 @@ func (e *Eth) Accounts() ([]web3.Address, error) {
 }
 
 // GetStorageAt returns the value from a storage position at a given address.
-func (e *Eth) GetStorageAt(addr web3.Address, slot web3.Hash, block web3.BlockNumber) (web3.Hash, error) {
+func (e *Eth) GetStorageAt(addr web3.Address, slot web3.Hash, block web3.BlockNumberOrHash) (web3.Hash, error) {
 	var hash web3.Hash
-	err := e.c.Call("eth_getStorageAt", &hash, addr, slot, block.String())
+	err := e.c.Call("eth_getStorageAt", &hash, addr, slot, block.Location())
 	return hash, err
 }
 
@@ -150,18 +150,18 @@ func (e *Eth) GetTransactionReceipt(hash web3.Hash) (*web3.Receipt, error) {
 }
 
 // GetNonce returns the nonce of the account
-func (e *Eth) GetNonce(addr web3.Address, blockNumber web3.BlockNumber) (uint64, error) {
+func (e *Eth) GetNonce(addr web3.Address, blockNumber web3.BlockNumberOrHash) (uint64, error) {
 	var nonce string
-	if err := e.c.Call("eth_getTransactionCount", &nonce, addr, blockNumber.String()); err != nil {
+	if err := e.c.Call("eth_getTransactionCount", &nonce, addr, blockNumber.Location()); err != nil {
 		return 0, err
 	}
 	return parseUint64orHex(nonce)
 }
 
 // GetBalance returns the balance of the account of given address.
-func (e *Eth) GetBalance(addr web3.Address, blockNumber web3.BlockNumber) (*big.Int, error) {
+func (e *Eth) GetBalance(addr web3.Address, blockNumber web3.BlockNumberOrHash) (*big.Int, error) {
 	var out string
-	if err := e.c.Call("eth_getBalance", &out, addr, blockNumber.String()); err != nil {
+	if err := e.c.Call("eth_getBalance", &out, addr, blockNumber.Location()); err != nil {
 		return nil, err
 	}
 	b, ok := new(big.Int).SetString(out[2:], 16)

--- a/structs.go
+++ b/structs.go
@@ -54,6 +54,10 @@ func (h Hash) String() string {
 	return "0x" + hex.EncodeToString(h[:])
 }
 
+func (h Hash) Location() string {
+	return h.String()
+}
+
 type Block struct {
 	Number             uint64
 	Hash               Hash
@@ -153,6 +157,10 @@ const (
 	Pending              = -3
 )
 
+func (b BlockNumber) Location() string {
+	return b.String()
+}
+
 func (b BlockNumber) String() string {
 	switch b {
 	case Latest:
@@ -173,4 +181,8 @@ func EncodeBlock(block ...BlockNumber) BlockNumber {
 		return Latest
 	}
 	return block[0]
+}
+
+type BlockNumberOrHash interface {
+	Location() string
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -170,12 +170,17 @@ func (t *TestServer) HTTPAddr() string {
 }
 
 // ProcessBlock processes a new block
-func (t *TestServer) ProcessBlock() error {
-	_, err := t.SendTxn(&web3.Transaction{
+func (t *TestServer) ProcessBlockWithReceipt() (*web3.Receipt, error) {
+	receipt, err := t.SendTxn(&web3.Transaction{
 		From:  t.accounts[0],
 		To:    &DummyAddr,
 		Value: big.NewInt(10),
 	})
+	return receipt, err
+}
+
+func (t *TestServer) ProcessBlock() error {
+	_, err := t.ProcessBlockWithReceipt()
 	return err
 }
 


### PR DESCRIPTION
There are some state endpoints (StorageAt, Balance, Code or TransactionCount) that be queried both at a block number or by block hash. Right now there is only support for block number (or block label like "latest" or "pending). This PR adds support to query those endpoints by block hash as well.