### PR TITLE
Adding Functionality to Sign Transactions Created by Contract Type.

### DIFF
--- a/contract/contract_test.go
+++ b/contract/contract_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/umbracle/go-web3/abi"
 	"github.com/umbracle/go-web3/jsonrpc"
 	"github.com/umbracle/go-web3/testutil"
+	"github.com/umbracle/go-web3/wallet"
 )
 
 var (
@@ -90,9 +91,14 @@ func TestDeployContract(t *testing.T) {
 
 	txn := DeployContract(p, s.Account(0), abi, bin, web3.Address{0x1}, 1000)
 
-	// if err := txn.SignAndSend(); err != nil {
-	// 	t.Fatal(err)
-	// }
+	key, err := wallet.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := txn.SignAndSend(key, 1); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := txn.Wait(); err != nil {
 		t.Fatal(err)

--- a/contract/contract_test.go
+++ b/contract/contract_test.go
@@ -90,9 +90,10 @@ func TestDeployContract(t *testing.T) {
 
 	txn := DeployContract(p, s.Account(0), abi, bin, web3.Address{0x1}, 1000)
 
-	if err := txn.Do(); err != nil {
-		t.Fatal(err)
-	}
+	// if err := txn.SignAndSend(); err != nil {
+	// 	t.Fatal(err)
+	// }
+
 	if err := txn.Wait(); err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/key.go
+++ b/wallet/key.go
@@ -43,7 +43,7 @@ func (k *Key) Sign(hash []byte) ([]byte, error) {
 	return append(sig, term)[1:], nil
 }
 
-func newKey(priv *ecdsa.PrivateKey) *Key {
+func NewKey(priv *ecdsa.PrivateKey) *Key {
 	return &Key{
 		priv: priv,
 		pub:  &priv.PublicKey,
@@ -63,7 +63,7 @@ func GenerateKey() (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newKey(priv), nil
+	return NewKey(priv), nil
 }
 
 func EcrecoverMsg(msg, signature []byte) (web3.Address, error) {

--- a/wallet/wallet_hd.go
+++ b/wallet/wallet_hd.go
@@ -88,5 +88,5 @@ func NewWalletFromMnemonic(mnemonic string) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newKey(priv), nil
+	return NewKey(priv), nil
 }

--- a/wallet/wallet_priv.go
+++ b/wallet/wallet_priv.go
@@ -16,5 +16,5 @@ func NewWalletFromPrivKey(p []byte) (*Key, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newKey(priv), nil
+	return NewKey(priv), nil
 }


### PR DESCRIPTION
**Summary**

This pull request is being submitted to add functionality to sign transactions created by a web3.Contract. 

Currently when creating a contract.Txn, the transaction is sent to the network through the `Do()` or `DoAndWait()` receiver functions. In these functions, the transaction is validated, the `gasPrice` and `gasLimit` are set and the `contract.Txn` is converted to a `&web3.Transaction`. The function then sends the transaction, however the transaction is never signed. Currently, the only way to sign a transaction is by using the `web3.Transaction` type, however there is no way to convert the `contract.Txn` type to a `web3.Transaction` because the `contract.Txn` has unexported fields.

In this pull request, functionality was added to  the `Do()` receiver function in order to sign the transaction before sending it to the network. To achieve this, the function now takes two arguments, a `key` with a type of `*wallet.Key` and a `chainID` with a type of `uint64`. 
```go
func (t *Txn) SignAndSend(key *wallet.Key, chainID uint64) 
```

Code from the _Wallet_ section in the README was integrated to sign the transaction and can be seen below:

```go 

// Create the signer object and sign
signer := wallet.NewEIP155Signer(chainID)
txn, _ = signer.SignTx(txn, key)

```

The new function is exactly the same as the `Do()` function, but has the added functionality mentioned above.

The `Do()` function was renamed to `SignAndSend()` to be more descriptive of the updated functionality of the receiver function. The `DoAndWait()` function was also renamed to `SignSendAndWait()`. This added functionality allows for developers to easily sign transactions created by contracts without having to create additional code to convert the `contract.Txn` to a `web3.Transaction`.  Please let me know if you have any feedback or additional changes that you would like me to make to the PR, I am all ears! Thank you for taking the time to read through my PR.

**Edit 11/03/21:**
I have also changed the `newKey()` function in the wallets module to be exported so that it is accessible through the wallets module. Currently, there is no way for a developer to create a new key from an existing private key string, however allowing for the `newKey()` function to be public and accessible through the wallets package allows for a developer to pass in an ecdsa.PrivateKey that was created from an existing private key string. 