### PR TITLE
Added new method to set maxConns limit for jsonrpc transport

### DIFF
--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -42,3 +42,8 @@ func (c *Client) Close() error {
 func (c *Client) Call(method string, out interface{}, params ...interface{}) error {
 	return c.transport.Call(method, out, params...)
 }
+
+// SetMaxConnsLimit sets the maximum number of connections that can be established with a host
+func (c *Client) SetMaxConnsLimit(count int) {
+	c.transport.SetMaxConnsPerHost(count)
+}

--- a/jsonrpc/transport/http.go
+++ b/jsonrpc/transport/http.go
@@ -73,3 +73,8 @@ func (h *HTTP) Call(method string, out interface{}, params ...interface{}) error
 	}
 	return nil
 }
+
+// SetMaxConnsPerHost sets the maximum number of connections that can be established with a host
+func (h *HTTP) SetMaxConnsPerHost(count int) {
+	h.client.MaxConnsPerHost = count
+}

--- a/jsonrpc/transport/transport.go
+++ b/jsonrpc/transport/transport.go
@@ -10,6 +10,9 @@ type Transport interface {
 	// Call makes a jsonrpc request
 	Call(method string, out interface{}, params ...interface{}) error
 
+	// SetMaxConnsPerHost sets the maximum number of connections that can be established with a host
+	SetMaxConnsPerHost(count int)
+
 	// Close closes the transport connection if necessary
 	Close() error
 }

--- a/jsonrpc/transport/websocket.go
+++ b/jsonrpc/transport/websocket.go
@@ -251,6 +251,10 @@ func (s *stream) Subscribe(method string, callback func(b []byte)) (func() error
 	return cancel, nil
 }
 
+// SetMaxConnsPerHost implements the transport interface
+func (s *stream) SetMaxConnsPerHost(count int) {
+}
+
 type websocketCodec struct {
 	conn *websocket.Conn
 }


### PR DESCRIPTION
This PR allows setting the `MaxConnsPerHost` in  jsonrpc http transport.