### PR TITLE
Best effort encoding + overload definitions

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -91,6 +91,7 @@ func (a *ABI) UnmarshalJSON(data []byte) error {
 	}
 
 	a.Methods = make(map[string]*Method)
+	a.MethodsBySignature = make(map[string]*Method)
 	a.Events = make(map[string]*Event)
 
 	for _, field := range fields {
@@ -111,7 +112,7 @@ func (a *ABI) UnmarshalJSON(data []byte) error {
 
 			name := overloadedName(field.Name, func(s string) bool { _, ok := a.Methods[s]; return ok })
 			method := &Method{
-				Name:    name,
+				Name:    field.Name,
 				Const:   c,
 				Inputs:  field.Inputs.Type(),
 				Outputs: field.Outputs.Type(),
@@ -122,7 +123,7 @@ func (a *ABI) UnmarshalJSON(data []byte) error {
 		case "event":
 			name := overloadedName(field.Name, func(s string) bool { _, ok := a.Events[s]; return ok })
 			a.Events[name] = &Event{
-				Name:      name,
+				Name:      field.Name,
 				Anonymous: field.Anonymous,
 				Inputs:    field.Inputs.Type(),
 			}

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestAbi(t *testing.T) {
+	methodOutput := &Method{
+		Name:    "abc",
+		Inputs:  &Type{kind: KindTuple, raw: "tuple", tuple: []*TupleElem{}},
+		Outputs: &Type{kind: KindTuple, raw: "tuple", tuple: []*TupleElem{}},
+	}
 	cases := []struct {
 		Input  string
 		Output *ABI
@@ -22,11 +27,10 @@ func TestAbi(t *testing.T) {
 			]`,
 			Output: &ABI{
 				Methods: map[string]*Method{
-					"abc": &Method{
-						Name:    "abc",
-						Inputs:  &Type{kind: KindTuple, raw: "tuple", tuple: []*TupleElem{}},
-						Outputs: &Type{kind: KindTuple, raw: "tuple", tuple: []*TupleElem{}},
-					},
+					"abc": methodOutput,
+				},
+				MethodsBySignature: map[string]*Method{
+					"abc()": methodOutput,
 				},
 				Events: map[string]*Event{},
 			},

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -47,6 +47,76 @@ func TestAbi(t *testing.T) {
 	}
 }
 
+func TestAbi_Polymorphism(t *testing.T) {
+	// This ABI contains 2 "transfer" functions (polymorphism)
+	const polymorphicABI = `[
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "address",
+                    "name": "_token",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+		{
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "_amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]`
+
+	abi, err := NewABI(polymorphicABI)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, abi.Methods, 2)
+	assert.Equal(t, abi.GetMethod("transfer").Sig(), "transfer(address,address,uint256)")
+	assert.Equal(t, abi.GetMethod("transfer0").Sig(), "transfer(address,uint256)")
+	assert.NotEmpty(t, abi.GetMethodBySignature("transfer(address,address,uint256)"))
+	assert.NotEmpty(t, abi.GetMethodBySignature("transfer(address,uint256)"))
+}
+
 func TestAbi_HumanReadable(t *testing.T) {
 	cases := []string{
 		"event Transfer(address from, address to, uint256 amount)",

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -1,8 +1,8 @@
 package abi
 
 import (
-	"encoding/hex"
 	"fmt"
+	"github.com/umbracle/go-web3"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -180,17 +180,8 @@ func encodeAddress(v reflect.Value) ([]byte, error) {
 		v = convertArrayToBytes(v)
 	}
 	if v.Kind() == reflect.String {
-		strValue := v.String()
-		if !strings.HasPrefix(strValue, "0x") {
-			return nil, fmt.Errorf("missing 0x prefix")
-		}
-
-		bytesValue, err := hex.DecodeString(strings.TrimPrefix("0x", strValue))
-		if err != nil {
-			return nil, fmt.Errorf("invalid address %s", strValue)
-		}
-
-		return encodeAddress(reflect.ValueOf(bytesValue))
+		web3Address := web3.HexToAddress(v.String())
+		return encodeAddress(reflect.ValueOf(web3Address))
 	}
 	return leftPad(v.Bytes(), 32), nil
 }

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -180,8 +180,11 @@ func encodeAddress(v reflect.Value) ([]byte, error) {
 		v = convertArrayToBytes(v)
 	}
 	if v.Kind() == reflect.String {
-		web3Address := web3.HexToAddress(v.String())
-		return encodeAddress(reflect.ValueOf(web3Address))
+		var addr web3.Address
+		if err := addr.UnmarshalText([]byte(v.String())); err != nil {
+			return nil, err
+		}
+		v = reflect.ValueOf(addr.Bytes())
 	}
 	return leftPad(v.Bytes(), 32), nil
 }

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -459,7 +459,6 @@ func TestEncodingBestEffort(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(res2, c.Expected) {
-				fmt.Println(reflect.ValueOf(res2), reflect.ValueOf(c.Expected))
 				t.Fatal("bad")
 			}
 			if tt.kind == KindTuple {

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -184,6 +184,20 @@ func TestEncoding(t *testing.T) {
 			},
 		},
 		{
+			// tuple with address as string
+			"tuple(address a)",
+			map[string]interface{}{
+				"a": web3.Address{0x1}.String(),
+			},
+		},
+		{
+			// tuple address and input as string
+			"tuple(address[] a)",
+			map[string]interface{}{
+				"a": []string{web3.Address{0x1}.String(), web3.Address{0x2}.String()},
+			},
+		},
+		{
 			// First dynamic second static
 			"tuple(int32[] a, int32[2] b)",
 			map[string]interface{}{

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -54,11 +54,6 @@ func TestEncoding(t *testing.T) {
 			big.NewInt(-10),
 		},
 		{
-			// int as float64
-			"int256",
-			float64(-10),
-		},
-		{
 			"bytes5",
 			[5]byte{0x1, 0x2, 0x3, 0x4, 0x5},
 		},
@@ -77,11 +72,6 @@ func TestEncoding(t *testing.T) {
 		{
 			"address[]",
 			[]web3.Address{{1}, {2}},
-		},
-		{
-			// addresses as strings
-			"address[]",
-			[]string{web3.Address{1}.String(), web3.Address{2}.String()},
 		},
 		{
 			"bytes10[]",
@@ -104,11 +94,6 @@ func TestEncoding(t *testing.T) {
 		{
 			"uint8[]",
 			[]uint8{1, 2},
-		},
-		{
-			// uint as float64
-			"uint8[]",
-			[]float64{1, 2},
 		},
 		{
 			"string[]",
@@ -196,20 +181,6 @@ func TestEncoding(t *testing.T) {
 				"a": []web3.Address{
 					{0x1},
 				},
-			},
-		},
-		{
-			// tuple with address as string
-			"tuple(address a)",
-			map[string]interface{}{
-				"a": web3.Address{0x1}.String(),
-			},
-		},
-		{
-			// tuple address and input as string
-			"tuple(address[] a)",
-			map[string]interface{}{
-				"a": []string{web3.Address{0x1}.String(), web3.Address{0x2}.String()},
 			},
 		},
 		{
@@ -543,7 +514,6 @@ func testEncodeDecode(t *testing.T, server *testutil.TestServer, tt *Type, input
 	}
 
 	if !reflect.DeepEqual(res2, input) {
-		fmt.Println(reflect.TypeOf(res2), reflect.TypeOf(input))
 		return fmt.Errorf("bad")
 	}
 	if tt.kind == KindTuple {

--- a/go.sum
+++ b/go.sum
@@ -110,16 +110,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
-github.com/umbracle/fastrlp v0.0.0-20210128110402-41364ca56ca8 h1:lWWKP+Oi7FSORlB3Y8rLz1Q7OOxtD8vecmtYOSNkIpo=
-github.com/umbracle/fastrlp v0.0.0-20210128110402-41364ca56ca8/go.mod h1:z0AyVhz/7VbuYSaCB+tFgypZKD1DJL76ATih6XqFlig=
-github.com/umbracle/fastrlp v0.0.0-20211210202053-92c528b55dea h1:KkTT5DT0SPmtNlQLSAI9jj0l2kkhn55Tl+txokkiWxQ=
-github.com/umbracle/fastrlp v0.0.0-20211210202053-92c528b55dea/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
-github.com/umbracle/fastrlp v0.0.0-20211228214822-d284b9a1ca89 h1:1HVAbF+D8wO8q7u+VMVZPysfZDdAdPdTDn5YECH2xrM=
-github.com/umbracle/fastrlp v0.0.0-20211228214822-d284b9a1ca89/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
-github.com/umbracle/fastrlp v0.0.0-20211228220138-9c20635803fb h1:jFYwAm/Nn6aWh2QCtejD0Ys/QVNKgf1AStCMONzcEDs=
-github.com/umbracle/fastrlp v0.0.0-20211228220138-9c20635803fb/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
-github.com/umbracle/fastrlp v0.0.0-20211228223544-26f56490122f h1:swxOU4cwCfjk8Uv/80lOantbwVAoUIzDgm+sZpqX/oY=
-github.com/umbracle/fastrlp v0.0.0-20211228223544-26f56490122f/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17 h1:ZZy8Rj2SqGcZn1hTcoLdwFBROzrf5KiuRwhp8G4nnfA=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,16 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
+github.com/umbracle/fastrlp v0.0.0-20210128110402-41364ca56ca8 h1:lWWKP+Oi7FSORlB3Y8rLz1Q7OOxtD8vecmtYOSNkIpo=
+github.com/umbracle/fastrlp v0.0.0-20210128110402-41364ca56ca8/go.mod h1:z0AyVhz/7VbuYSaCB+tFgypZKD1DJL76ATih6XqFlig=
+github.com/umbracle/fastrlp v0.0.0-20211210202053-92c528b55dea h1:KkTT5DT0SPmtNlQLSAI9jj0l2kkhn55Tl+txokkiWxQ=
+github.com/umbracle/fastrlp v0.0.0-20211210202053-92c528b55dea/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
+github.com/umbracle/fastrlp v0.0.0-20211228214822-d284b9a1ca89 h1:1HVAbF+D8wO8q7u+VMVZPysfZDdAdPdTDn5YECH2xrM=
+github.com/umbracle/fastrlp v0.0.0-20211228214822-d284b9a1ca89/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
+github.com/umbracle/fastrlp v0.0.0-20211228220138-9c20635803fb h1:jFYwAm/Nn6aWh2QCtejD0Ys/QVNKgf1AStCMONzcEDs=
+github.com/umbracle/fastrlp v0.0.0-20211228220138-9c20635803fb/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
+github.com/umbracle/fastrlp v0.0.0-20211228223544-26f56490122f h1:swxOU4cwCfjk8Uv/80lOantbwVAoUIzDgm+sZpqX/oY=
+github.com/umbracle/fastrlp v0.0.0-20211228223544-26f56490122f/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17 h1:ZZy8Rj2SqGcZn1hTcoLdwFBROzrf5KiuRwhp8G4nnfA=
 github.com/umbracle/fastrlp v0.0.0-20211229195328-c1416904ae17/go.mod h1:c8J0h9aULj2i3umrfyestM6jCq0LK0U6ly6bWy96nd4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
This PR fixes 2 newly found issues:

**Improvement**:
- When parsing JSON as `interface{}` in Go, all numbers are parsed as `float64`. Currently the library will fail to encode the params if a number is passed as `float64` so we cast into an `int64` before encoding it.
- We would like to pass addresses as strings such as "0x905B88EFf8Bda1543d4d6f4aA05afef143D27E18". Currently the library will fail if we pass a string when expecting an `address`.

**Bug fix**:
This library currently does not account for overloaded functions and events. In Solidity, polymorphism makes it such that multiple methods or events can have the same name but different parameters. Because of this, we must index the methods by appending an index to their name when multiple methods have the same name (same logic as used in go-ethereum).
For example if we have two methods `method(uint256)` and `method(address)`, we will store the methods as `method` and `method0`. We also index methods by signature instead of name to be able to retrieve a method by signature.