### PR TITLE
Fix parse func types in NewMethod

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -33,7 +33,7 @@ func (a *ABI) GetMethodBySignature(methodSignature string) *Method {
 }
 
 func (a *ABI) addEvent(e *Event) {
-	if len(a.Methods) == 0 {
+	if len(a.Events) == 0 {
 		a.Events = map[string]*Event{}
 	}
 	a.Events[e.Name] = e
@@ -194,8 +194,8 @@ func NewMethod(name string) (*Method, error) {
 }
 
 var (
-	funcRegexpWithReturn    = regexp.MustCompile(`(.*)\((.*)\)(.*) returns \((.*)\)`)
-	funcRegexpWithoutReturn = regexp.MustCompile(`(.*)\((.*)\)(.*)`)
+	funcRegexpWithReturn    = regexp.MustCompile(`(\w*)\((.*)\)(.*) returns \((.*)\)`)
+	funcRegexpWithoutReturn = regexp.MustCompile(`(\w*)\((.*)\)(.*)`)
 )
 
 func parseMethodSignature(name string) (string, *Type, *Type, error) {

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -122,11 +122,11 @@ func TestAbi_Polymorphism(t *testing.T) {
 
 func TestAbi_HumanReadable(t *testing.T) {
 	cases := []string{
-		//"constructor(string symbol, string name)", // TODO
+		"constructor(string symbol, string name)",
 		"function transferFrom(address from, address to, uint256 value)",
 		"function balanceOf(address owner) view returns (uint256 balance)",
 		"event Transfer(address indexed from, address indexed to, address value)",
-		//"error InsufficientBalance(account owner, uint balance)", // TODO
+		"error InsufficientBalance(address owner, uint256 balance)",
 		"function addPerson(tuple(string name, uint16 age) person)",
 		"function addPeople(tuple(string name, uint16 age)[] person)",
 		"function getPerson(uint256 id) view returns (tuple(string name, uint16 age))",
@@ -136,6 +136,9 @@ func TestAbi_HumanReadable(t *testing.T) {
 	assert.NoError(t, err)
 
 	expect := &ABI{
+		Constructor: &Method{
+			Inputs: MustNewType("tuple(string symbol, string name)"),
+		},
 		Methods: map[string]*Method{
 			"transferFrom": &Method{
 				Name:    "transferFrom",
@@ -173,8 +176,13 @@ func TestAbi_HumanReadable(t *testing.T) {
 				Inputs: MustNewType("tuple(uint256 indexed id, tuple(string name, uint16 age) person)"),
 			},
 		},
+		Errors: map[string]*Error{
+			"InsufficientBalance": &Error{
+				Name:   "InsufficientBalance",
+				Inputs: MustNewType("tuple(address owner, uint256 balance)"),
+			},
+		},
 	}
-
 	assert.Equal(t, expect, vv)
 }
 

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -1,7 +1,6 @@
 package abi
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -123,13 +122,60 @@ func TestAbi_Polymorphism(t *testing.T) {
 
 func TestAbi_HumanReadable(t *testing.T) {
 	cases := []string{
-		"event Transfer(address from, address to, uint256 amount)",
-		"function symbol() returns (string)",
+		//"constructor(string symbol, string name)", // TODO
+		"function transferFrom(address from, address to, uint256 value)",
+		"function balanceOf(address owner) view returns (uint256 balance)",
+		"event Transfer(address indexed from, address indexed to, address value)",
+		//"error InsufficientBalance(account owner, uint balance)", // TODO
+		"function addPerson(tuple(string name, uint16 age) person)",
+		"function addPeople(tuple(string name, uint16 age)[] person)",
+		"function getPerson(uint256 id) view returns (tuple(string name, uint16 age))",
+		"event PersonAdded(uint256 indexed id, tuple(string name, uint16 age) person)",
 	}
 	vv, err := NewABIFromList(cases)
 	assert.NoError(t, err)
 
-	fmt.Println(vv.Methods["symbol"].Inputs.String())
+	expect := &ABI{
+		Methods: map[string]*Method{
+			"transferFrom": &Method{
+				Name:    "transferFrom",
+				Inputs:  MustNewType("tuple(address from, address to, uint256 value)"),
+				Outputs: MustNewType("tuple()"),
+			},
+			"balanceOf": &Method{
+				Name:    "balanceOf",
+				Inputs:  MustNewType("tuple(address owner)"),
+				Outputs: MustNewType("tuple(uint256 balance)"),
+			},
+			"addPerson": &Method{
+				Name:    "addPerson",
+				Inputs:  MustNewType("tuple(tuple(string name, uint16 age) person)"),
+				Outputs: MustNewType("tuple()"),
+			},
+			"addPeople": &Method{
+				Name:    "addPeople",
+				Inputs:  MustNewType("tuple(tuple(string name, uint16 age)[] person)"),
+				Outputs: MustNewType("tuple()"),
+			},
+			"getPerson": &Method{
+				Name:    "getPerson",
+				Inputs:  MustNewType("tuple(uint256 id)"),
+				Outputs: MustNewType("tuple(tuple(string name, uint16 age))"),
+			},
+		},
+		Events: map[string]*Event{
+			"Transfer": &Event{
+				Name:   "Transfer",
+				Inputs: MustNewType("tuple(address indexed from, address indexed to, address value)"),
+			},
+			"PersonAdded": &Event{
+				Name:   "PersonAdded",
+				Inputs: MustNewType("tuple(uint256 indexed id, tuple(string name, uint16 age) person)"),
+			},
+		},
+	}
+
+	assert.Equal(t, expect, vv)
 }
 
 func TestAbi_ParseMethodSignature(t *testing.T) {

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -125,6 +125,7 @@ func TestAbi_HumanReadable(t *testing.T) {
 		"constructor(string symbol, string name)",
 		"function transferFrom(address from, address to, uint256 value)",
 		"function balanceOf(address owner) view returns (uint256 balance)",
+		"function balanceOf() view returns ()",
 		"event Transfer(address indexed from, address indexed to, address value)",
 		"error InsufficientBalance(address owner, uint256 balance)",
 		"function addPerson(tuple(string name, uint16 age) person)",
@@ -152,6 +153,11 @@ func TestAbi_HumanReadable(t *testing.T) {
 				Name:    "balanceOf",
 				Inputs:  MustNewType("tuple(address owner)"),
 				Outputs: MustNewType("tuple(uint256 balance)"),
+			},
+			"balanceOf0": &Method{
+				Name:    "balanceOf",
+				Inputs:  MustNewType("tuple()"),
+				Outputs: MustNewType("tuple()"),
 			},
 			"addPerson": &Method{
 				Name:    "addPerson",

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -135,6 +135,9 @@ func TestAbi_HumanReadable(t *testing.T) {
 	vv, err := NewABIFromList(cases)
 	assert.NoError(t, err)
 
+	// make it nil to not compare it and avoid writing each method twice for the test
+	vv.MethodsBySignature = nil
+
 	expect := &ABI{
 		Constructor: &Method{
 			Inputs: MustNewType("tuple(string symbol, string name)"),

--- a/contract/contract_test.go
+++ b/contract/contract_test.go
@@ -37,7 +37,7 @@ func TestContractNoInput(t *testing.T) {
 	assert.Equal(t, vals["0"], big.NewInt(1))
 
 	abi1, err := abi.NewABIFromList([]string{
-		"function set () view returns (uint256)",
+		"function set() view returns (uint256)",
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This PR fixes the parsing of NewMethod as human readable ABI and makes it compatible with the one from [ethers.js](https://docs.ethers.io/v5/api/utils/abi/formats/#abi-formats--human-readable-abi). Closes #132.