### PR TITLE
Decode bare uint and int as 256 bytes

### DIFF
--- a/abi/type.go
+++ b/abi/type.go
@@ -385,11 +385,11 @@ func decodeSimpleType(str string) (*Type, error) {
 		ok = true
 	}
 
-	// Only int and uint need bytes for sure, 'bytes' may
+	// int and uint without bytes default to 256, 'bytes' may
 	// have or not, the rest dont have bytes
 	if t == "int" || t == "uint" {
 		if !ok {
-			return nil, fmt.Errorf("int and uint expect bytes")
+			bytes = 256
 		}
 	} else if t != "bytes" && ok {
 		return nil, fmt.Errorf("type %s does not expect bytes", t)

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -33,6 +33,16 @@ func TestType(t *testing.T) {
 			t: &Type{kind: KindSlice, t: reflect.SliceOf(int32T), raw: "int32[]", elem: &Type{kind: KindInt, size: 32, t: int32T, raw: "int32"}},
 		},
 		{
+			s: "int",
+			a: simpleType("int"),
+			t: &Type{kind: KindInt, size: 256, t: bigIntT, raw: "int256"},
+		},
+		{
+			s: "int[]",
+			a: simpleType("int[]"),
+			t: &Type{kind: KindSlice, t: reflect.SliceOf(bigIntT), raw: "int256[]", elem: &Type{kind: KindInt, size: 256, t: bigIntT, raw: "int256"}},
+		},
+		{
 			s: "bytes[2]",
 			a: simpleType("bytes[2]"),
 			t: &Type{
@@ -273,10 +283,6 @@ func TestType(t *testing.T) {
 		},
 		{
 			s:   "int[[",
-			err: true,
-		},
-		{
-			s:   "int",
 			err: true,
 		},
 		{


### PR DESCRIPTION
If 'int' and 'uint' types do not have bytes (i.e. int64) when parsing they default to int256 and uint256.