### PR TITLE
Encode strings to number as big.Int

### DIFF
--- a/abi/encode.go
+++ b/abi/encode.go
@@ -236,7 +236,10 @@ func encodeNum(v reflect.Value) ([]byte, error) {
 	case reflect.String:
 		n, ok := new(big.Int).SetString(v.String(), 10)
 		if !ok {
-			return nil, encodeErr(v, "number")
+			n, ok = new(big.Int).SetString(v.String()[2:], 16)
+			if !ok {
+				return nil, encodeErr(v, "number")
+			}
 		}
 		return encodeNum(reflect.ValueOf(n))
 

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -232,6 +232,14 @@ func encodeNum(v reflect.Value) ([]byte, error) {
 
 	case reflect.Float64:
 		return encodeNum(reflect.ValueOf(int64(v.Float())))
+
+	case reflect.String:
+		n, ok := new(big.Int).SetString(v.String(), 10)
+		if !ok {
+			return nil, encodeErr(v, "number")
+		}
+		return encodeNum(reflect.ValueOf(n))
+
 	default:
 		return nil, encodeErr(v, "number")
 	}

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -342,6 +342,7 @@ func TestEncoding(t *testing.T) {
 func TestEncodingBestEffort(t *testing.T) {
 	strAddress := "0xdbb881a51CD4023E4400CEF3ef73046743f08da3"
 	web3Address := web3.HexToAddress(strAddress)
+	overflowBigInt, _ := new(big.Int).SetString("50000000000000000000000000000000000000", 10)
 
 	cases := []struct {
 		Type     string
@@ -354,13 +355,28 @@ func TestEncodingBestEffort(t *testing.T) {
 			big.NewInt(50),
 		},
 		{
+			"uint40",
+			"50",
+			big.NewInt(50),
+		},
+		{
 			"int256",
 			float64(2),
 			big.NewInt(2),
 		},
 		{
+			"int256",
+			"50000000000000000000000000000000000000",
+			overflowBigInt,
+		},
+		{
 			"int256[]",
 			[]interface{}{float64(1), float64(2)},
+			[]*big.Int{big.NewInt(1), big.NewInt(2)},
+		},
+		{
+			"int256[]",
+			[]interface{}{"1", "2"},
 			[]*big.Int{big.NewInt(1), big.NewInt(2)},
 		},
 		{
@@ -369,14 +385,23 @@ func TestEncodingBestEffort(t *testing.T) {
 			big.NewInt(-10),
 		},
 		{
+			"int256",
+			"-10",
+			big.NewInt(-10),
+		},
+		{
 			"address[]",
 			[]interface{}{strAddress, strAddress},
 			[]web3.Address{web3Address, web3Address},
 		},
-
 		{
 			"uint8[]",
 			[]interface{}{float64(1), float64(2)},
+			[]uint8{1, 2},
+		},
+		{
+			"uint8[]",
+			[]interface{}{"1", "2"},
 			[]uint8{1, 2},
 		},
 		{
@@ -406,6 +431,17 @@ func TestEncodingBestEffort(t *testing.T) {
 			map[string]interface{}{
 				"a": web3Address,
 				"b": int64(266),
+			},
+		},
+		{
+			"tuple(address a, int64 b)",
+			map[string]interface{}{
+				"a": strAddress,
+				"b": "50000000000000000000000000000000000000",
+			},
+			map[string]interface{}{
+				"a": web3Address,
+				"b": overflowBigInt,
 			},
 		},
 	}

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -360,6 +360,11 @@ func TestEncodingBestEffort(t *testing.T) {
 			big.NewInt(50),
 		},
 		{
+			"uint40",
+			"0x32",
+			big.NewInt(50),
+		},
+		{
 			"int256",
 			float64(2),
 			big.NewInt(2),
@@ -367,6 +372,11 @@ func TestEncodingBestEffort(t *testing.T) {
 		{
 			"int256",
 			"50000000000000000000000000000000000000",
+			overflowBigInt,
+		},
+		{
+			"int256",
+			"0x259DA6542D43623D04C5112000000000",
 			overflowBigInt,
 		},
 		{
@@ -438,6 +448,17 @@ func TestEncodingBestEffort(t *testing.T) {
 			map[string]interface{}{
 				"a": strAddress,
 				"b": "50000000000000000000000000000000000000",
+			},
+			map[string]interface{}{
+				"a": web3Address,
+				"b": overflowBigInt,
+			},
+		},
+		{
+			"tuple(address a, int256 b)",
+			map[string]interface{}{
+				"a": strAddress,
+				"b": "0x259DA6542D43623D04C5112000000000",
 			},
 			map[string]interface{}{
 				"a": web3Address,

--- a/abi/encoding_test.go
+++ b/abi/encoding_test.go
@@ -434,7 +434,7 @@ func TestEncodingBestEffort(t *testing.T) {
 			},
 		},
 		{
-			"tuple(address a, int64 b)",
+			"tuple(address a, int256 b)",
 			map[string]interface{}{
 				"a": strAddress,
 				"b": "50000000000000000000000000000000000000",


### PR DESCRIPTION
Currently, go-web3 does not support passing numbers as strings. Big numbers in Solidity that overflow the maximum Go size (such as uint256 and int256) need to be passed as Big Ints but the majority of users would actually prefer to pass these arguments as strings like it is done in `web3js` and `ethers.js`. 

This PR improves the best effort by trying to encode strings as numbers by transforming them into big.Int. 