### PR TITLE
Fix: jsonrpc: use header arg in websocket dialer for jsonrpc

### DIFF
--- a/jsonrpc/transport/websocket.go
+++ b/jsonrpc/transport/websocket.go
@@ -17,7 +17,7 @@ func newWebsocket(url string, headers map[string]string) (Transport, error) {
 	for k, v := range headers {
 		wsHeaders.Add(k, v)
 	}
-	wsConn, _, err := websocket.DefaultDialer.Dial(url, http.Header{})
+	wsConn, _, err := websocket.DefaultDialer.Dial(url, wsHeaders)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Headers were added in #140, but not plumbed through to the websocket dialer.