### PR TITLE
Add missing Gas field to CallMsg

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -190,6 +190,7 @@ type CallMsg struct {
 	To       *Address
 	Data     []byte
 	GasPrice uint64
+	Gas      *big.Int
 	Value    *big.Int
 }
 

--- a/structs_marshal.go
+++ b/structs_marshal.go
@@ -192,6 +192,9 @@ func (c *CallMsg) MarshalJSON() ([]byte, error) {
 	if c.Value != nil {
 		o.Set("value", a.NewString(fmt.Sprintf("0x%x", c.Value)))
 	}
+	if c.Gas != nil {
+		o.Set("gas", a.NewString(fmt.Sprintf("0x%x", c.Gas)))
+	}
 
 	res := o.MarshalTo(nil)
 	defaultArena.Put(a)


### PR DESCRIPTION
# Description

According to the [Ethereum JSON-RPC spec](https://eth.wiki/json-rpc/API#eth_call), methods `estimateGas` and `call` can take in a transaction object.

The field `Gas` (gas limit) was missing from `CallMsg`. This PR adds that additional missing field