### PR TITLE
Correct the topic field in log filters

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -196,7 +196,7 @@ type CallMsg struct {
 
 type LogFilter struct {
 	Address   []Address
-	Topics    []*Hash
+	Topics    [][]*Hash
 	BlockHash *Hash
 	From      *BlockNumber
 	To        *BlockNumber

--- a/structs_marshal.go
+++ b/structs_marshal.go
@@ -216,12 +216,25 @@ func (l *LogFilter) MarshalJSON() ([]byte, error) {
 	}
 
 	v := a.NewArray()
-	for indx, topic := range l.Topics {
-		if topic == nil {
+	for indx, topics := range l.Topics {
+		if topics == nil {
 			v.SetArrayItem(indx, a.NewNull())
-		} else {
-			v.SetArrayItem(indx, a.NewString(topic.String()))
+
+			continue
 		}
+
+		innerTopicArray := a.NewArray()
+		for innerIndx, innerTopic := range topics {
+			if innerTopic == nil {
+				innerTopicArray.SetArrayItem(innerIndx, a.NewNull())
+
+				continue
+			}
+
+			innerTopicArray.SetArrayItem(innerIndx, a.NewString(innerTopic.String()))
+		}
+
+		v.SetArrayItem(indx, innerTopicArray)
 	}
 	o.Set("topics", v)
 

--- a/structs_marshal.go
+++ b/structs_marshal.go
@@ -239,7 +239,7 @@ func (l *LogFilter) MarshalJSON() ([]byte, error) {
 	o.Set("topics", v)
 
 	if l.BlockHash != nil {
-		o.Set("blockhash", a.NewString((*l.BlockHash).String()))
+		o.Set("blockHash", a.NewString((*l.BlockHash).String()))
 	}
 	if l.From != nil {
 		o.Set("fromBlock", a.NewString((*l.From).String()))

--- a/structs_marshal_test.go
+++ b/structs_marshal_test.go
@@ -1,0 +1,95 @@
+package web3
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func generateHashPtr(input string) *Hash {
+	res := HexToHash(input)
+	return &res
+}
+
+func TestLogFilter_MarshalJSON(t *testing.T) {
+	testTable := []struct {
+		name   string
+		topics [][]*Hash
+	}{
+		{
+			"match any topic",
+			[][]*Hash{
+				nil,
+				{},
+			},
+		},
+		{
+			"match single topic in pos. 1",
+			[][]*Hash{
+				{
+					generateHashPtr("0xa"),
+				},
+			},
+		},
+		{
+			"match single topic in pos. 2",
+			[][]*Hash{
+				{},
+				{
+					generateHashPtr("0xb"),
+				},
+			},
+		},
+		{
+			"match topic in pos. 1 AND pos. 2",
+			[][]*Hash{
+				{
+					generateHashPtr("0xa"),
+				},
+				{
+					generateHashPtr("0xb"),
+				},
+			},
+		},
+		{
+			"match topic A or B in pos. 1 AND C or D in pos. 2",
+			[][]*Hash{
+				{
+					generateHashPtr("0xa"),
+					generateHashPtr("0xb"),
+				},
+				{
+					generateHashPtr("0xc"),
+					generateHashPtr("0xd"),
+				},
+			},
+		},
+	}
+
+	defaultLogFilter := &LogFilter{
+		Address:   []Address{HexToAddress("0x123")},
+		Topics:    nil,
+		BlockHash: generateHashPtr("0xabc"),
+	}
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			defaultLogFilter.Topics = testCase.topics
+
+			// Marshal it to JSON
+			output, marshalErr := defaultLogFilter.MarshalJSON()
+			if marshalErr != nil {
+				t.Fatalf("Unable to marshal value, %v", marshalErr)
+			}
+
+			// Unmarshal it from JSON
+			reverseOutput := &LogFilter{}
+			unmarshalErr := json.Unmarshal(output, reverseOutput)
+			if unmarshalErr != nil {
+				t.Fatalf("Unable to unmarshal value, %v", unmarshalErr)
+			}
+
+			// Assert that the original and unmarshalled values match
+			assert.Equal(t, defaultLogFilter, reverseOutput)
+		})
+	}
+}

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -38,7 +38,7 @@ const (
 // FilterConfig is a tracker filter configuration
 type FilterConfig struct {
 	Address []web3.Address `json:"address"`
-	Topics  []*web3.Hash   `json:"topics"`
+	Topics  [][]*web3.Hash `json:"topics"`
 	Start   uint64
 	Hash    string
 	Async   bool
@@ -49,12 +49,25 @@ func (f *FilterConfig) buildHash() {
 	for _, i := range f.Address {
 		h.Write([]byte(i.String()))
 	}
-	for _, i := range f.Topics {
-		if i == nil {
+	for _, topics := range f.Topics {
+		if topics == nil {
 			h.Write([]byte("empty"))
-		} else {
-			h.Write([]byte(i.String()))
+
+			continue
 		}
+
+		innerTopicArray := make([]byte, 0)
+		for _, innerTopic := range topics {
+			if innerTopic == nil {
+				innerTopicArray = append(innerTopicArray, []byte("empty")...)
+
+				continue
+			}
+
+			innerTopicArray = append(innerTopicArray, []byte(innerTopic.String())...)
+		}
+
+		h.Write(innerTopicArray)
 	}
 	f.Hash = hex.EncodeToString(h.Sum(nil))
 }

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -56,18 +56,15 @@ func (f *FilterConfig) buildHash() {
 			continue
 		}
 
-		innerTopicArray := make([]byte, 0)
 		for _, innerTopic := range topics {
 			if innerTopic == nil {
-				innerTopicArray = append(innerTopicArray, []byte("empty")...)
+				h.Write([]byte("empty"))
 
 				continue
 			}
 
-			innerTopicArray = append(innerTopicArray, []byte(innerTopic.String())...)
+			h.Write([]byte(innerTopic.String()))
 		}
-
-		h.Write(innerTopicArray)
 	}
 	f.Hash = hex.EncodeToString(h.Sum(nil))
 }

--- a/tracker/tracker_test.go
+++ b/tracker/tracker_test.go
@@ -133,7 +133,7 @@ func TestFilterIntegration(t *testing.T) {
 	typ, _ := abi.NewType("uint256")
 	topic, _ := abi.EncodeTopic(typ, 1)
 
-	logs = testFilter(t, client.Eth(), &FilterConfig{Topics: []*web3.Hash{nil, &topic}})
+	logs = testFilter(t, client.Eth(), &FilterConfig{Topics: [][]*web3.Hash{nil, {&topic}}})
 	if len(logs) != 20 {
 		t.Fatal("bad")
 	}
@@ -167,13 +167,13 @@ func TestFilterIntegrationEventHash(t *testing.T) {
 	}
 
 	eventTopicID := abi0.Events["A"].ID()
-	logs := testFilter(t, client.Eth(), &FilterConfig{Topics: []*web3.Hash{&eventTopicID}})
+	logs := testFilter(t, client.Eth(), &FilterConfig{Topics: [][]*web3.Hash{{&eventTopicID}}})
 	if len(logs) != 10 {
 		t.Fatal("bad")
 	}
 
 	eventTopicID[1] = 1
-	logs = testFilter(t, client.Eth(), &FilterConfig{Topics: []*web3.Hash{&eventTopicID}})
+	logs = testFilter(t, client.Eth(), &FilterConfig{Topics: [][]*web3.Hash{{&eventTopicID}}})
 	if len(logs) != 0 {
 		t.Fatal("bad")
 	}


### PR DESCRIPTION
# Description

Currently, the log filter does not support `Topics` [according to the spec](https://eth.wiki/json-rpc/API#eth_getlogs):
> topics: Array of DATA, - (optional) Array of 32 Bytes DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with “or” options.

Notice the last sentence:
> Each topic can also be an array of DATA with “or” options.

This means that the `Topics` field of a log filter can accept an array of arrays, and not just a simple array.

A great example of usage is provided with [go-ethereum](https://pkg.go.dev/github.com/ethereum/go-ethereum#FilterQuery):
> 	// The Topic list restricts matches to particular event topics. Each event has a list
	// of topics. Topics matches a prefix of that list. An empty element slice matches any
	// topic. Non-empty elements represent an alternative that matches any of the
	// contained topics.
	//
	// Examples:
	// {} or nil          matches any topic list
	// {{A}}              matches topic A in first position
	// {{}, {B}}          matches any topic in first position AND B in second position
	// {{A}, {B}}         matches topic A in first position AND B in second position
	// {{A, B}, {C, D}}   matches topic (A OR B) in first position AND (C OR D) in second position


The fix contained in this PR makes sure that the log filter conforms to the spec, by expanding the `Topics` field to accept arrays of topics