### PR TITLE
Add ENS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,9 @@ Resolve names on the Ethereum Name Service registrar.
 import (
     "fmt"
 
-    web3 "github.com/umbracle/go-web3"
     "github.com/umbracle/go-web3/jsonrpc"
-    "github.com/umbracle/go-web3/contract/builtin/ens"
+    "github.com/umbracle/go-web3/ens"
 )
-
-var mainnetAddress = web3.HexToAddress("0x314159265dD8dbb310642f98f50C066173C1259b")
 
 func main() {
 	client, err := jsonrpc.NewClient("https://mainnet.infura.io")
@@ -168,12 +165,14 @@ func main() {
         panic(err)
     }
 
-	resolver := ens.NewENSResolver(mainnetAddress, client)
-	addr, err := resolver.Resolve("ens_address")
+	ens, err := ens.NewENS(ens.WithClient(client))
 	if err != nil {
 		panic(err)
 	}
-
+	addr, err := ens.Resolve("ens_address")
+	if err != nil {
+		panic(err)
+	}
     fmt.Println(addr)
 }
 ```

--- a/ens/address_mapping.go
+++ b/ens/address_mapping.go
@@ -1,0 +1,12 @@
+package ens
+
+import "github.com/umbracle/go-web3"
+
+var defaultEnsAddr = web3.HexToAddress("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e")
+
+var builtinEnsAddr = map[uint64]web3.Address{
+	1: defaultEnsAddr,
+	3: defaultEnsAddr,
+	4: defaultEnsAddr,
+	5: defaultEnsAddr,
+}

--- a/ens/ens.go
+++ b/ens/ens.go
@@ -1,0 +1,88 @@
+package ens
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/umbracle/go-web3"
+	"github.com/umbracle/go-web3/contract/builtin/ens"
+	"github.com/umbracle/go-web3/jsonrpc"
+)
+
+type EnsConfig struct {
+	Logger   *log.Logger
+	Client   *jsonrpc.Client
+	Addr     string
+	Resolver web3.Address
+}
+
+type EnsOption func(*EnsConfig)
+
+func WithResolver(resolver web3.Address) EnsOption {
+	return func(c *EnsConfig) {
+		c.Resolver = resolver
+	}
+}
+
+func WithLogger(logger *log.Logger) EnsOption {
+	return func(c *EnsConfig) {
+		c.Logger = logger
+	}
+}
+
+func WithAddress(addr string) EnsOption {
+	return func(c *EnsConfig) {
+		c.Addr = addr
+	}
+}
+
+func WithClient(client *jsonrpc.Client) EnsOption {
+	return func(c *EnsConfig) {
+		c.Client = client
+	}
+}
+
+type ENS struct {
+	config *EnsConfig
+}
+
+func NewENS(opts ...EnsOption) (*ENS, error) {
+	config := &EnsConfig{}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if config.Client == nil {
+		// addr must be set
+		if config.Addr == "" {
+			return nil, fmt.Errorf("jsonrpc addr is empty")
+		}
+		client, err := jsonrpc.NewClient(config.Addr)
+		if err != nil {
+			return nil, err
+		}
+		config.Client = client
+	}
+
+	if config.Resolver == web3.ZeroAddress {
+		// try to get the resolver address from the builtin list
+		chainID, err := config.Client.Eth().ChainID()
+		if err != nil {
+			return nil, err
+		}
+		addr, ok := builtinEnsAddr[chainID.Uint64()]
+		if !ok {
+			return nil, fmt.Errorf("no builtin Ens resolver found for chain %s", chainID)
+		}
+		config.Resolver = addr
+	}
+	ens := &ENS{
+		config: config,
+	}
+	return ens, nil
+}
+
+func (e *ENS) Resolve(name string) (web3.Address, error) {
+	resolver := ens.NewENSResolver(e.config.Resolver, e.config.Client)
+	return resolver.Resolve(name)
+}

--- a/ens/ens_test.go
+++ b/ens/ens_test.go
@@ -1,0 +1,18 @@
+package ens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/umbracle/go-web3"
+	"github.com/umbracle/go-web3/testutil"
+)
+
+func TestENS_Resolve(t *testing.T) {
+	ens, err := NewENS(WithAddress(testutil.TestInfuraEndpoint(t)))
+	assert.NoError(t, err)
+
+	addr, err := ens.Resolve("arachnid.eth")
+	assert.NoError(t, err)
+	assert.Equal(t, web3.HexToAddress("0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5"), addr)
+}

--- a/jsonrpc/client.go
+++ b/jsonrpc/client.go
@@ -16,6 +16,7 @@ type endpoints struct {
 	n *Net
 	d *Debug
 }
+
 type Config struct {
 	headers map[string]string
 }

--- a/networks.go
+++ b/networks.go
@@ -14,5 +14,5 @@ const (
 	Rinkeby Network = 4
 
 	// Goerli is the Clique testnet
-	Goerli = 5
+	Goerli Network = 5
 )


### PR DESCRIPTION
This PR adds a new wrapper module to resolve ENS domains. Before, go-web3 only had support to interact with the smart contract but the user had to supply the resolver address. Now, this new module introduces a more straightforward Api to do it, hard coding the default address for the default ENS resolver in the main networks.